### PR TITLE
Input disabled filter icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 elm-stuff
 # elm-repl generated files
 repl-temp-*
+.idea/

--- a/src/CarwowTheme/Filters.elm
+++ b/src/CarwowTheme/Filters.elm
@@ -88,8 +88,8 @@ filterGroup items =
 
 {-| Placeholder
 -}
-standardFilterView : String -> List (FilterGroupItem msg) -> Html.Html msg
-standardFilterView label items =
+standardFilterView : String -> String -> List (FilterGroupItem msg) ->  Html.Html msg
+standardFilterView label selectedIcon items =
     let
         itemsCount =
             List.length items
@@ -121,32 +121,41 @@ standardFilterView label items =
                 firstSelectedFilter
     in
         if itemsCount > 1 then
-            filterView label selectedFiltersLabel content
+            filterView label selectedFiltersLabel selectedIcon content
         else
             text ""
 
 
 {-| Placeholder
 -}
-filterView : String -> String -> List (Html.Html msg) -> Html.Html msg
-filterView label selectedFiltersLabel content =
+filterView : String -> String -> String -> List (Html.Html msg) -> Html.Html msg
+filterView label selectedFiltersLabel selectedIcon content =
     li [ class "filter" ]
         [ div
             [ class "filter__tooltip tooltip tooltip--no-border" ]
             [ div [ class "tooltip__label" ]
-                [ div [ class "filter__label" ]
-                    [ text label
-                    , icon "caret_down" { size = "x-small", colour = "dark-grey", colouring = "outline" }
+                [ div [ class "filter__icon" ]
+                    [
+                          icon selectedIcon { size = "small", colour = "dark-grey", colouring = "outline" }
                     ]
-                , div [ class "filter__current-selection" ] [ text selectedFiltersLabel ]
+                    , div[]
+                    [
+                    div [ class "filter__label" ]
+                        [ text label
+                        , icon "caret_down" { size = "xx-small", colour = "dark-grey", colouring = "outline" }
+                        ]
+                        , div [ class "filter__current-selection" ] [ text selectedFiltersLabel ]
+                    ]
                 ]
             , div
                 [ class "tooltip-dropdown tooltip-dropdown--bottom" ]
                 [ div [ class "tooltip-dropdown__arrow" ]
                     []
                 , div [ class "tooltip-dropdown__content" ]
-                    [ ul [ class "filter-dropdown__inputs list-unstyled" ]
+                    [ div [ class "tooltip-dropdown__content" ]
+                        [ ul [ class "filter-dropdown__inputs list-unstyled" ]
                         content
+                        ]
                     ]
                 ]
             ]

--- a/src/CarwowTheme/Filters.elm
+++ b/src/CarwowTheme/Filters.elm
@@ -129,14 +129,13 @@ standardFilterView label selectedIcon items =
 {-| Placeholder
 -}
 filterView : String -> String -> String -> List (Html.Html msg) -> Html.Html msg
-filterView label selectedFiltersLabel selectedIcon content =
+filterView label selectedFiltersLabel filterIcon content =
     li [ class "filter" ]
         [ div
             [ class "filter__tooltip tooltip tooltip--no-border" ]
             [ div [ class "tooltip__label" ]
                 [ div [ class "filter__icon" ]
-                    [
-                          icon selectedIcon { size = "small", colour = "dark-grey", colouring = "outline" }
+                    [ icon filterIcon { size = "small", colour = "dark-grey", colouring = "outline" }
                     ]
                     , div[]
                     [

--- a/src/CarwowTheme/Inputs.elm
+++ b/src/CarwowTheme/Inputs.elm
@@ -53,13 +53,15 @@ select :
     -> List (Html.Html msgType)
     -> String
     -> (String -> msgType)
+    -> Bool
     -> Html.Html msgType
-select id options value msg =
+select id options value msg isDisabled =
     Html.div [ Html.Attributes.class "select" ]
         [ Html.select
             [ Html.Attributes.id id
             , Html.Attributes.value value
             , onChange msg
+            , disabled isDisabled
             ]
             options
         ]


### PR DESCRIPTION
- Added select to accept disabled param to accommodate  a change on leasing filters. Advise if there is a better way in handling this.

- Filter groups now need icons to align with the new design changes.


****
Just leaving this PR here for now to review after elm-theme has been resolved in quotes