### PR TITLE
Add data attribute in modal body to fix scroll issues in safari iOS

### DIFF
--- a/src/CarwowTheme/Drawer.elm
+++ b/src/CarwowTheme/Drawer.elm
@@ -130,6 +130,7 @@ view model properties toggleOpenMsg toggleCloseMsg loadMoreButton =
                         ]
                     , div
                         [ class "notification-drawer__body"
+                        , Html.Attributes.attribute "data-modal-content-body" "true"
                         ]
                         [ properties.body
                         , loadMoreButton

--- a/src/CarwowTheme/Drawer.elm
+++ b/src/CarwowTheme/Drawer.elm
@@ -101,6 +101,8 @@ view model properties toggleOpenMsg toggleCloseMsg loadMoreButton =
                 , name model.id
                 , checked (model.state == Opened)
                 , onClick toggleOpenMsg
+                , Html.Attributes.attribute "data-open-modal-input" "true"
+                , Html.Attributes.attribute "data-modal-body-no-scroll" "true"
                 ]
                 []
             , input
@@ -109,6 +111,7 @@ view model properties toggleOpenMsg toggleCloseMsg loadMoreButton =
                 , id (model.id ++ "-close")
                 , name model.id
                 , onClick toggleCloseMsg
+                , Html.Attributes.attribute "data-close-modal-input" "true"
                 ]
                 []
             , div

--- a/src/CarwowTheme/Modal.elm
+++ b/src/CarwowTheme/Modal.elm
@@ -145,6 +145,7 @@ view model openModalEvent closeModalEvent properties =
                             [ ( "modal__body", True )
                             , ( "modal__body--no-padding", properties.paddingStyle == NoPadding )
                             ]
+                        , Html.Attributes.attribute "data-modal-content-body" "true"
                         ]
                         [ properties.body ]
                     , footer

--- a/src/CarwowTheme/Modal.elm
+++ b/src/CarwowTheme/Modal.elm
@@ -117,6 +117,8 @@ view model openModalEvent closeModalEvent properties =
                 , name "modal-make-model-selector"
                 , checked model.isOpen
                 , onClick openModalEvent
+                , Html.Attributes.attribute "data-open-modal-input" "true"
+                , Html.Attributes.attribute "data-modal-body-no-scroll" "true"
                 ]
                 []
             , input
@@ -125,6 +127,7 @@ view model openModalEvent closeModalEvent properties =
                 , id (model.id ++ "-close")
                 , name "modal-make-model-selector"
                 , onClick closeModalEvent
+                , Html.Attributes.attribute "data-close-modal-input" "true"
                 ]
                 []
             , div [ Html.Attributes.class "modal-overlay", id "modal-make-model-selector" ]


### PR DESCRIPTION
Adding data attributes to modal and drawer components so that the fix body scroll and fix safari iOS scroll from the carwow theme can be triggered