### PR TITLE
Add data attributes to modals and drawer to fix body and ios scroll lock

### DIFF
--- a/src/CarwowTheme/Drawer.elm
+++ b/src/CarwowTheme/Drawer.elm
@@ -101,6 +101,7 @@ view model properties toggleOpenMsg toggleCloseMsg loadMoreButton =
                 , name model.id
                 , checked (model.state == Opened)
                 , onClick toggleOpenMsg
+                , Html.Attributes.attribute "data-modal-input" "true"
                 , Html.Attributes.attribute "data-open-modal-input" "true"
                 , Html.Attributes.attribute "data-modal-body-no-scroll" "true"
                 ]
@@ -111,6 +112,7 @@ view model properties toggleOpenMsg toggleCloseMsg loadMoreButton =
                 , id (model.id ++ "-close")
                 , name model.id
                 , onClick toggleCloseMsg
+                , Html.Attributes.attribute "data-modal-input" "true"
                 , Html.Attributes.attribute "data-close-modal-input" "true"
                 ]
                 []

--- a/src/CarwowTheme/Modal.elm
+++ b/src/CarwowTheme/Modal.elm
@@ -117,6 +117,7 @@ view model openModalEvent closeModalEvent properties =
                 , name "modal-make-model-selector"
                 , checked model.isOpen
                 , onClick openModalEvent
+                , Html.Attributes.attribute "data-modal-input" "true"
                 , Html.Attributes.attribute "data-open-modal-input" "true"
                 , Html.Attributes.attribute "data-modal-body-no-scroll" "true"
                 ]
@@ -127,12 +128,15 @@ view model openModalEvent closeModalEvent properties =
                 , id (model.id ++ "-close")
                 , name "modal-make-model-selector"
                 , onClick closeModalEvent
+                , Html.Attributes.attribute "data-modal-input" "true"
                 , Html.Attributes.attribute "data-close-modal-input" "true"
                 ]
                 []
-            , div [ Html.Attributes.class "modal-overlay"
-                  , id "modal-make-model-selector"
-                  , attribute "data-close-on-esc" "true" ]
+            , div
+                [ Html.Attributes.class "modal-overlay"
+                , id "modal-make-model-selector"
+                , attribute "data-close-on-esc" "true"
+                ]
                 [ label
                     [ Html.Attributes.class "modal-overlay__cancel"
                     , Html.Attributes.for (model.id ++ "-close")


### PR DESCRIPTION
 Add data attributes that were recently added to the modal and drawer in the carwow theme, for the fix scroll so it doesn't collide with other input change events