### PR TITLE
Allow html to be passed into the title for modals + elm format

### DIFF
--- a/src/CarwowTheme/Icons.elm
+++ b/src/CarwowTheme/Icons.elm
@@ -40,15 +40,18 @@ icon iconName iconProperties =
             [ use [ xlinkHref ("#sprite_icon_" ++ iconName) ] []
             ]
 
+
 {-| Embeds a Make icon, with the given make slug and optional properties
 -}
 makeIcon : String -> Maybe Properties -> Html.Html msg
 makeIcon makeSlug iconProperties =
     let
-      iconName = ("makes/" ++ String.join "_" (String.split "-" (String.toLower makeSlug)))
+        iconName =
+            ("makes/" ++ String.join "_" (String.split "-" (String.toLower makeSlug)))
     in
-      case iconProperties of
-        Nothing ->
-          icon iconName  { size = "large", colour = "grey", colouring = "filled" }
-        Just iconProperties ->
-          icon iconName iconProperties
+        case iconProperties of
+            Nothing ->
+                icon iconName { size = "large", colour = "grey", colouring = "filled" }
+
+            Just iconProperties ->
+                icon iconName iconProperties

--- a/src/CarwowTheme/Modal.elm
+++ b/src/CarwowTheme/Modal.elm
@@ -28,7 +28,7 @@ type alias Model =
 -}
 type alias ModalProperties msg =
     { body : Html msg
-    , title : String
+    , title : Maybe (Html msg)
     , paddingStyle : PaddingStyle
     , footer : Maybe (Html msg)
     , secondaryAction : Maybe (Html msg)
@@ -101,6 +101,15 @@ view model openModalEvent closeModalEvent properties =
                 ]
                 [ icon "close_b" { size = "small", colour = "black", colouring = "outline" } ]
 
+        title =
+            case properties.title of
+                Just content ->
+                    div [ Html.Attributes.class "modal__title modal__title--centered" ]
+                        [ content ]
+
+                Nothing ->
+                    Html.text ""
+
         footer =
             case properties.footer of
                 Just content ->
@@ -145,8 +154,7 @@ view model openModalEvent closeModalEvent properties =
                 , div [ Html.Attributes.class "modal" ]
                     [ div [ Html.Attributes.class "modal__header modal__header--with-border" ]
                         [ Maybe.withDefault (Html.text "") properties.secondaryAction
-                        , div [ Html.Attributes.class "modal__title modal__title--centered" ]
-                            [ text properties.title ]
+                        , title
                         , closeButton
                         ]
                     , div


### PR DESCRIPTION
Implemented like the footer. Allow the title of a modal to accept HTML types for some variants in title styling 